### PR TITLE
Aggregate cluster roles to known cluster roles

### DIFF
--- a/config/rbac/enterprisecontractpolicy_editor_role.yaml
+++ b/config/rbac/enterprisecontractpolicy_editor_role.yaml
@@ -3,6 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: enterprisecontractpolicy-editor-role
+  labels:
+    # Bind this role to users already bound to the "edit" ClusterRole.
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
 - apiGroups:
   - appstudio.redhat.com

--- a/config/rbac/enterprisecontractpolicy_viewer_role.yaml
+++ b/config/rbac/enterprisecontractpolicy_viewer_role.yaml
@@ -3,6 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: enterprisecontractpolicy-viewer-role
+  labels:
+    # Bind this role to users already bound to the "view" ClusterRole.
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
 - apiGroups:
   - appstudio.redhat.com


### PR DESCRIPTION
ClusterRoles can be automatically bound to users who are already bound
to another ClusterRole. By doing so, we prevent having to manually bind
the ClusterRole to each namespace that uses the CRD.

[0] https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>