### PR TITLE
Fix image build workflow

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -16,16 +16,10 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup Go environment
-        uses: actions/setup-go@v3.0.0
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.17
-
-      - name: Cache dependencies
-        uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
+          cache: true
+          go-version-file: go.mod
 
       - name: Cache Docker layers
         uses: actions/cache@v3


### PR DESCRIPTION
Seems to be failing for a while. This makes sure that the go version used is in sync with the version in `go.mod`.