### PR TITLE
Place a copy of the CRD in api/config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ docs: $(wildcard api/v1alpha1/*.go) ## Generate documentation
 .PHONY: manifests
 manifests: controller-gen kcp-manifests ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=enterprise-contract-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) rbac:roleName=enterprise-contract-role crd webhook paths="./..." output:crd:artifacts:config=api/config
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/api/config/appstudio.redhat.com_enterprisecontractpolicies.yaml
+++ b/api/config/appstudio.redhat.com_enterprisecontractpolicies.yaml
@@ -1,0 +1,131 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  name: enterprisecontractpolicies.appstudio.redhat.com
+spec:
+  group: appstudio.redhat.com
+  names:
+    kind: EnterpriseContractPolicy
+    listKind: EnterpriseContractPolicyList
+    plural: enterprisecontractpolicies
+    shortNames:
+    - ecp
+    singular: enterprisecontractpolicy
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: EnterpriseContractPolicy is the Schema for the enterprisecontractpolicies
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: EnterpriseContractPolicySpec is used to configure the Enterprise
+              Contract Policy
+            properties:
+              authorization:
+                description: Authorization for per component release approvals
+                properties:
+                  components:
+                    description: Components based authorization
+                    items:
+                      description: Authorization defines a release approval on a component
+                        basis
+                      properties:
+                        authorizer:
+                          description: Authorizer is the email address of the person
+                            authorizing the release
+                          type: string
+                        changeId:
+                          description: ChangeID is the identifier of the change, e.g.
+                            git commit id
+                          type: string
+                        repository:
+                          description: Repository of the component sources
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              configuration:
+                description: Configuration handles policy modification configuration
+                  (collections, exclusions, inclusions)
+                properties:
+                  collections:
+                    description: Collections set of predefined rules.
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: set
+                  exclude:
+                    description: Exclude set of policy exclusions that, in case of
+                      failure, do not block the success of the outcome.
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: set
+                  include:
+                    description: Include set of policy inclusions that are added to
+                      the policy evaluation. These override excluded rules.
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: set
+                type: object
+              description:
+                description: Description of the policy or it's intended use
+                type: string
+              exceptions:
+                description: 'Exceptions under which the policy is evaluated as successful
+                  even if the listed policy checks have reported failure Deprecated:
+                  This has been replaced by the configuration.'
+                properties:
+                  nonBlocking:
+                    description: NonBlocking set of policy exceptions that in case
+                      of failure do not block the success of the outcome
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: set
+                type: object
+              publicKey:
+                description: Public key used to validate the signature of images and
+                  attestations
+                type: string
+              rekorUrl:
+                description: URL of the Rekor instance. Empty string disables Rekor
+                  integration
+                type: string
+              sources:
+                description: One or more source urls for the policy rules
+                items:
+                  type: string
+                minItems: 1
+                type: array
+            required:
+            - sources
+            type: object
+          status:
+            description: EnterpriseContractPolicyStatus defines the observed state
+              of EnterpriseContractPolicy
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
Makes for easier consumption when requiring just the api module.