### PR TITLE
tekton-ci: Use volumeClaimTemplate instead of static PVC

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -19,6 +19,10 @@ spec:
     bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest
   workspaces:
     - name: workspace
-      persistentVolumeClaim:
-        claimName: app-studio-default-workspace
-      subPath: ec-controller-check-{{ revision }}
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -26,6 +26,10 @@ spec:
     bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest
   workspaces:
     - name: workspace
-      persistentVolumeClaim:
-        claimName: app-studio-default-workspace
-      subPath: ec-controller-push-{{ revision }}
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi


### PR DESCRIPTION
volumeClaimTemplate provides PVC cleanup out-of-box.