### PR TITLE
Cleanup out-of date checks

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -24,9 +24,7 @@ jobs:
           cache-dependency-path: '**/go.sum'
 
       - name: Test
-        run: |
-          touch api/v1alpha1/* # forces manifest regeneration, some changes (e.g. controller-gen update) don't reflect in code
-          make test
+        run: make test
 
       - name: Check for uncommitted changes
         run: |

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,8 @@ docs: $(wildcard $(CRD_DEF)/*.go) ## Generate documentation
 GEN_DEPS=\
  controllers/enterprisecontractpolicy_controller.go \
  api/v1alpha1/enterprisecontractpolicy_types.go \
- api/v1alpha1/groupversion_info.go
+ api/v1alpha1/groupversion_info.go \
+ tools/go.sum
 
 config/crd/bases/%.yaml: $(GEN_DEPS)
 	$(CONTROLLER_GEN) rbac:roleName=enterprise-contract-role crd webhook paths=./... output:crd:artifacts:config=config/crd/bases


### PR DESCRIPTION
We can rely on `tools/go.sum` being updated so we don't need to touch files to force manifest regeneration. With this we can have the same workflow locally and on GitHub.