### PR TITLE
Update enterprisecontractpolicy-sample spec

### DIFF
--- a/config/samples/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy.yaml
+++ b/config/samples/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy.yaml
@@ -5,16 +5,17 @@ metadata:
 spec:
   description: My custom enterprise contract policy configuration
   sources:
-    - quay.io/hacbs-contract/ec-release-policy:latest
+    - policy:
+        - quay.io/hacbs-contract/ec-release-policy:latest
   exceptions: # Deprecated. Use configuration as seen below
     nonBlocking: # Deprecated. Use excludeRules as seen below
       - not_useful
       - test:conftest-clair
   configuration:
-    excludeRules:
+    exclude:
       - not_useful
       - test:conftest-clair
-    includeRules:
+    include:
       - always_checked
     collections:
       - salsa_one_collection


### PR DESCRIPTION
This commit updates the sample yaml file in an attempt to address the following error which is currently reported when trying to create apply the sample:

```console
$ kubectl apply -f config/samples/

The request is invalid: patch: Invalid value: "
{\"apiVersion\":\"appstudio.redhat.com/v1alpha1\"
\"kind\":\"EnterpriseContractPolicy\"
\"metadata\":{\"annotations\":{
\"kubectl.kubernetes.io/last-applied-configuration\":\"
  {\\\"apiVersion\\\":\\\"appstudio.redhat.com/v1alpha1\\\"
\\\"kind\\\":\\\"EnterpriseContractPolicy\\\"
\\\"metadata\\\":{\\\"annotations\\\":{}
\\\"name\\\":\\\"enterprisecontractpolicy-sample\\\"
\\\"namespace\\\":\\\"default\\\"}
\\\"spec\\\":{\\\"configuration\\\":{\\
  \"collections\\\":[\\\"salsa_one_collection\\\"]
\\\"excludeRules\\\":[\\\"not_useful\\\"
\\\"test:conftest-clair\\\"]
\\\"includeRules\\\":[\\\"always_checked\\\"]}
\\\"description\\\":\\
  \"My custom enterprise contract policy configuration\\\"
\\\"exceptions\\\":{\\\"nonBlocking\\\":[\\\"not_useful\\\"
\\\"test:conftest-clair\\\"]}
\\\"sources\\\":[\\
  \"quay.io/hacbs-contract/ec-release-policy:latest\\\"]}}\\n\"}
\"creationTimestamp\":\"2023-03-12T12:49:15Z\"
\"generation\":1
\"managedFields\":[{\"apiVersion\":\"appstudio.redhat.com/v1alpha1\"
\"fieldsType\":\"FieldsV1\"
\"fieldsV1\":{\"f:metadata\":{\"f:annotations\":{\".\":{}
\"f:kubectl.kubernetes.io/last-applied-configuration\":{}}}
\"f:spec\":{\".\":{}
\"f:configuration\":{\".\":{}
\"f:collections\":{\".\":{}
\"v:\\\"salsa_one_collection\\\"\":{}}
\"f:exclude\":{\".\":{}
\"v:\\\"not_useful\\\"\":{}
\"v:\\\"test:conftest-clair\\\"\":{}}
\"f:include\":{\".\":{}
\"v:\\\"always_checked\\\"\":{}}}
\"f:description\":{}
\"f:exceptions\":{\".\":{}
\"f:nonBlocking\":{\".\":{}
\"v:\\\"not_useful\\\"\":{}
\"v:\\\"test:conftest-clair\\\"\":{}}}
\"f:sources\":{}}}
\"manager\":\"kubectl-client-side-apply\"
\"operation\":\"Update\"
\"time\":\"2023-03-12T12:49:15Z\"}]
\"name\":\"enterprisecontractpolicy-sample\"
\"namespace\":\"default\"
\"resourceVersion\":\"291910\"
\"uid\":\"010d0f7a-0fd0-4daf-ba4e-4740103918f9\"}
\"spec\":{\"configuration\":{\"collections\":[\"salsa_one_collection\"]
\"excludeRules\":[\"not_useful\"
\"test:conftest-clair\"]
\"includeRules\":[\"always_checked\"]}
\"description\":\"My custom enterprise contract policy configuration\"
\"exceptions\":{\"nonBlocking\":[\"not_useful\"
\"test:conftest-clair\"]}
\"sources\":[\"quay.io/hacbs-contract/ec-release-policy:latest\"]}}":
strict decoding error: unknown field "spec.configuration.excludeRules"

 unknown field "spec.configuration.includeRules"
```

With the changes in this commit the apply command succeeds.

```console
$ kubectl get ecp
NAME                              AGE
enterprisecontractpolicy-sample   5s
```